### PR TITLE
Fix pagination stops returning results too early

### DIFF
--- a/src/Accelo/APIRequest/RequestSender.php
+++ b/src/Accelo/APIRequest/RequestSender.php
@@ -260,7 +260,7 @@
 			// Handle pagination
 			$returnLimit = Paginator::DEFAULT_LIMIT; // Used to tell the RequestResponse if there are more results
 			if ($paginator !== null){
-				$returnLimit = $paginator->getPage();
+				$returnLimit = $paginator->getLimit();
 				$queryParameters['_page'] = $paginator->getPage();
 				$queryParameters['_limit'] = $paginator->getLimit();
 			}


### PR DESCRIPTION
Thanks for open sourcing this, this is looking very useful so far.

I'm using an Accelo deployment with a large number of records and noticed that the pagination stops returning results too early, this small change fixes it.