### PR TITLE
Handle fetching contract periods

### DIFF
--- a/src/Accelo/APIRequest/RequestSender.php
+++ b/src/Accelo/APIRequest/RequestSender.php
@@ -298,6 +298,12 @@
 				if (array_key_exists("collections", $objectsListed)){
 					$objectsListed = $objectsListed['collections'];
 				}
+				/**
+				 * Same as above for periods.
+				 */
+				elseif (array_key_exists("periods", $objectsListed)){
+					$objectsListed = $objectsListed['periods'];
+				}
 
 				$acceloObjectsParsed = [];
 


### PR DESCRIPTION
Another small change to handle contract periods from the `contracts/{contract_id}/periods` endpoint