### PR TITLE
Support custom Guzzle client via dependency injection

### DIFF
--- a/src/Accelo/APIRequest/RequestSender.php
+++ b/src/Accelo/APIRequest/RequestSender.php
@@ -24,6 +24,10 @@
 		public ClientCredentials $clientCredentials;
 		public Authentication $authentication;
 
+		public function __construct(private readonly Client $client = new Client())
+		{
+		}
+
 		private function getAPIFullURL(string $path): string{
 			return sprintf(
 					$this->apiBaseUrl,
@@ -147,8 +151,6 @@
 			?AdditionalFields $additionalFields,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
@@ -165,7 +167,7 @@
 				}
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"GET",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -240,8 +242,6 @@
 			?Paginator $paginator,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
@@ -281,7 +281,7 @@
 				$queryParameters['_limit'] = $paginator->getLimit();
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"GET",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -383,8 +383,6 @@
 			?AdditionalFields $additionalFields,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
@@ -401,7 +399,7 @@
 				}
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"PUT",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -474,8 +472,6 @@
 			?AdditionalFields $additionalFields,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
@@ -492,7 +488,7 @@
 				}
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"POST",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -564,8 +560,6 @@
 			?AdditionalFields $additionalFields = null,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
@@ -577,7 +571,7 @@
 				$formParams['_fields'] = $additionalFields->getFieldsAsCommaSeparatedList();
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"POST",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -650,15 +644,13 @@
 			string $fileContents,
 		): RequestResponse{
 
-			$client = new Client();
-
 			if ($this->authentication instanceof WebAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromWebToken();
 			}elseif ($this->authentication instanceof ServiceAuthentication){
 				$authorizationString = $this->getBearerAuthenticationStringFromServiceToken();
 			}
 
-			$response = $client->request(
+			$response = $this->client->request(
 				method:"POST",
 				uri: $this->getAPIFullURL($path),
 				options:[
@@ -739,7 +731,6 @@
 			string $scope,
 		): RequestResponse{
 
-			$client = new Client();
 			$clientID = $this->clientCredentials->clientID;
 
 			$postParameters = [
@@ -749,7 +740,7 @@
 			];
 
 			try {
-				$response = $client->request(
+				$response = $this->client->request(
 					method: "POST",
 					uri: $this->getOAuthFullURL("/authorize"),
 					options: [
@@ -789,7 +780,6 @@
 			int $expiresInSeconds,
 		): RequestResponse{
 
-			$client = new Client();
 			$clientID = $this->clientCredentials->clientID;
 			$clientSecret = $this->clientCredentials->clientSecret;
 			$basicAuthentication = sprintf(
@@ -810,7 +800,7 @@
 			];
 
 			try {
-				$response = $client->request(
+				$response = $this->client->request(
 					method: "POST",
 					uri: $this->getOAuthFullURL("/token"),
 					options: [
@@ -863,7 +853,6 @@
 			string $scope,
 			int $expiresInSeconds,
 		): RequestResponse{
-			$client = new Client();
 			$clientID = $this->clientCredentials->clientID;
 			$clientSecret = $this->clientCredentials->clientSecret;
 			$basicAuthentication = sprintf(
@@ -884,7 +873,7 @@
 			];
 
 			try {
-				$response = $client->request(
+				$response = $this->client->request(
 					method: "POST",
 					uri: $this->getOAuthFullURL("/token"),
 					options: [

--- a/src/Accelo/Accelo.php
+++ b/src/Accelo/Accelo.php
@@ -20,6 +20,10 @@
 		private ClientCredentials $clientCredentials;
 		private Authentication $authentication;
 
+		public function __construct(private readonly RequestSender $requestSender = new RequestSender())
+		{
+		}
+
 		public function setAPIBaseUrl(string $baseURL): void{
 			$this->apiBaseUrl = $baseURL;
 		}
@@ -50,12 +54,11 @@
 		 * @throws GuzzleException
 		 */
 		public function getAuthorizationURL(string $scope): string{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			$requestResponse = $requestSender->getAuthorizationURL(
+			$requestResponse = $this->requestSender->getAuthorizationURL(
 				scope: $scope,
 			);
 
@@ -71,12 +74,11 @@
 			string $accessCode,
 			int $expiresInSeconds,
 		): array{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			$requestResponse = $requestSender->getTokensFromAccessCode(
+			$requestResponse = $this->requestSender->getTokensFromAccessCode(
 				accessCode: $accessCode,
 				expiresInSeconds: $expiresInSeconds,
 			);
@@ -95,12 +97,11 @@
 			string $scope,
 			int $expiresInSeconds,
 		): array{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			$requestResponse = $requestSender->getTokensForServiceApplication(
+			$requestResponse = $this->requestSender->getTokensForServiceApplication(
 				scope: $scope,
 				expiresInSeconds: $expiresInSeconds,
 			);
@@ -119,13 +120,12 @@
 			string $objectType,
 			?AdditionalFields $additionalFields = null,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->getObject(
+			return $this->requestSender->getObject(
 				objectType: $objectType,
 				path: $endpoint,
 				additionalFields:$additionalFields,
@@ -144,13 +144,12 @@
 			?Search $search = null,
 			?Paginator $paginator = null,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->listObjects(
+			return $this->requestSender->listObjects(
 				objectType: $objectType,
 				path: $endpoint,
 				fields:$additionalFields,
@@ -170,13 +169,12 @@
 			Fields $fields = null,
 			?AdditionalFields $additionalFields = null,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->update(
+			return $this->requestSender->update(
 				objectType: $objectType,
 				path: $endpoint,
 				fields:$fields,
@@ -194,13 +192,12 @@
 			Fields $fields = null,
 			?AdditionalFields $additionalFields = null,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->create(
+			return $this->requestSender->create(
 				objectType: $objectType,
 				path: $endpoint,
 				fields:$fields,
@@ -217,13 +214,12 @@
 			string $objectType,
 			?AdditionalFields $additionalFields = null,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->runProgression(
+			return $this->requestSender->runProgression(
 				objectType: $objectType,
 				path: $endpoint,
 				additionalFields: $additionalFields,
@@ -239,13 +235,12 @@
 			string $fileName,
 			string $fileContents,
 		): RequestResponse{
-			$requestSender = new RequestSender();
-			$requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
-			$requestSender->setAPIVersionString($this->getAPIVersionString());
-			$requestSender->authentication = $this->authentication;
-			$requestSender->clientCredentials = $this->clientCredentials;
+			$this->requestSender->setAPIBaseUrl($this->getAPIBaseUrl());
+			$this->requestSender->setAPIVersionString($this->getAPIVersionString());
+			$this->requestSender->authentication = $this->authentication;
+			$this->requestSender->clientCredentials = $this->clientCredentials;
 
-			return $requestSender->uploadResource(
+			return $this->requestSender->uploadResource(
 				objectType: Resource::class,
 				path: $endpoint,
 				fileName: $fileName,

--- a/tests/GuzzleMockHandlerTest.php
+++ b/tests/GuzzleMockHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+	require_once __DIR__ . "/../vendor/autoload.php";
+
+	use FootbridgeMedia\Accelo\Accelo;
+	use FootbridgeMedia\Accelo\Activities\Activity;
+	use FootbridgeMedia\Accelo\APIRequest\RequestSender;
+	use FootbridgeMedia\Accelo\Authentication\AuthenticationType;
+	use FootbridgeMedia\Accelo\Authentication\WebAuthentication;
+	use FootbridgeMedia\Accelo\ClientCredentials\ClientCredentials;
+	use GuzzleHttp\Client;
+	use GuzzleHttp\Handler\MockHandler;
+	use GuzzleHttp\HandlerStack;
+	use GuzzleHttp\Psr7\Response;
+	use PHPUnit\Framework\TestCase;
+
+	final class GuzzleMockHandlerTest extends TestCase
+	{
+		public function testGuzzleMockHandler(){
+			$mock = new MockHandler([
+				new Response(
+					200,
+					[
+						"X-RateLimit-Reset" => time() + 3600,
+						"X-RateLimit-Remaining" => 4999,
+						"X-RateLimit-Limit" => 5000,
+					],
+					json_encode([
+						"response" => [
+							"id" => 1,
+							"subject" => "Hello world",
+							"confidential" => 0,
+						],
+						"meta" => [
+							"more_info" => "https://affinitylive.jira.com/wiki/display/APIS/Status+Codes#ok",
+							"status" => "ok",
+							"message" => "Everything executed as expected.",
+						],
+					])
+				),
+			]);
+			$client = new Client(["handler" => HandlerStack::create($mock)]);
+			$requestSender = new RequestSender($client);
+			$accelo = new Accelo($requestSender);
+
+			$authentication = new WebAuthentication();
+			$authentication->accessToken = bin2hex(random_bytes(16));
+			$authentication->refreshToken = bin2hex(random_bytes(16));
+			$authentication->authType = AuthenticationType::Bearer;
+			$accelo->setAuthentication($authentication);
+
+			$clientCredentials = new ClientCredentials();
+			$clientCredentials->deploymentName = "testing";
+			$clientCredentials->clientID = bin2hex(random_bytes(16));
+			$clientCredentials->clientSecret = bin2hex(random_bytes(16));
+			$accelo->setCredentials($clientCredentials);
+
+			$response = $accelo->get(
+				endpoint: "/activities/1",
+				objectType: Activity::class
+			);
+			$activity = $response->getFetchedObject();
+			$this->assertEquals($activity->id, 1);
+			$this->assertEquals($activity->subject, 'Hello world');
+			$this->assertEquals($activity->confidential, 0);
+		}
+	}


### PR DESCRIPTION
This adds support for a customised Guzzle client via dependency injection on the RequestSender and Accelo classes. This can then be used to mock Guzzle responses for testing, as shown in the included test.

This is a bit opinionated so no worries if you'd rather not accept this change!